### PR TITLE
expose AbstractVerticle's rxvertx instance

### DIFF
--- a/vertx-rx-java/src/main/java/io/vertx/rxjava/core/AbstractVerticle.java
+++ b/vertx-rx-java/src/main/java/io/vertx/rxjava/core/AbstractVerticle.java
@@ -75,4 +75,13 @@ public class AbstractVerticle extends io.vertx.core.AbstractVerticle {
   public Completable rxStop() {
     return null;
   }
+
+  /**
+   * Returns the rxjava vertx instance.
+   *
+   * @return the rx vertx instance
+   */
+  public io.vertx.rxjava.core.Vertx getRxVertx() {
+    return vertx;
+  }
 }

--- a/vertx-rx-java2/src/main/java/io/vertx/reactivex/core/AbstractVerticle.java
+++ b/vertx-rx-java2/src/main/java/io/vertx/reactivex/core/AbstractVerticle.java
@@ -75,4 +75,13 @@ public class AbstractVerticle extends io.vertx.core.AbstractVerticle {
   public Completable rxStop() {
     return null;
   }
+
+  /**
+   * Returns the rxjava2 vertx instance.
+   *
+   * @return the rx vertx instance
+   */
+  public io.vertx.reactivex.core.Vertx getRxVertx() {
+    return vertx;
+  }
 }


### PR DESCRIPTION
Add a method to AbstractVerticle to allow access to the rx.vertx instance for code other than that inheriting the class. Moved from [here](https://github.com/vert-x3/vertx-rx/pull/109).